### PR TITLE
Options for custom registries, cloning over SSH, and setting the project

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3'
+services:
+  tests:
+    image: buildkite/plugin-tester
+    volumes:
+      - ".:/plugin"

--- a/hooks/command
+++ b/hooks/command
@@ -1,15 +1,18 @@
 #!/bin/bash
-set -euo pipefail
+source $(dirname ${BASH_SOURCE})/common
 
 echo "+++ :julia: Running tests"
+julia --project=${project} -e "
+    using Pkg
 
-coverage=${BUILDKITE_PLUGIN_JULIA_TEST_COVERAGE:-true}
-julia_args=${BUILDKITE_PLUGIN_JULIA_TEST_JULIA_ARGS:-""}
-test_args=${BUILDKITE_PLUGIN_JULIA_TEST_TEST_ARGS:-""}
+    # We never update the registry when running tests, we assume if you wanted this done, you'd do it in the pre-command
+    Pkg.UPDATED_REGISTRY_THIS_SESSION[] = true
 
-julia --project -e "using Pkg
-                    Pkg.UPDATED_REGISTRY_THIS_SESSION[] = true
+    # In the event that you might need to fetch test-only dependencies that are private,
+    # we set Pkg to use SSH for cloning non-PkgServer-served packages here as well
+    ${USE_SSH_BLOCK}
 
-                    Pkg.test(; coverage=$coverage,
-                               julia_args=\`$julia_args\`,
-                               test_args=\`$test_args\`)"
+    Pkg.test(; coverage=$coverage,
+                julia_args=\`$julia_args\`,
+                test_args=\`$test_args\`)
+"

--- a/hooks/common
+++ b/hooks/common
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -euo pipefail
+
+coverage=${BUILDKITE_PLUGIN_JULIA_TEST_COVERAGE:-true}
+julia_args=${BUILDKITE_PLUGIN_JULIA_TEST_JULIA_ARGS:-""}
+test_args=${BUILDKITE_PLUGIN_JULIA_TEST_TEST_ARGS:-""}
+project=${BUILDKITE_PLUGIN_JULIA_TEST_PROJECT:-.}
+
+# Allow the user to purposefully skip updating the registry (e.g. we know it's already been done)
+REGISTRY_SKIP_BLOCK=""
+if [[ "${BUILDKITE_PLUGIN_JULIA_TEST_UPDATE_REGISTRY:-true}" != "true" ]]; then
+    REGISTRY_SKIP_BLOCK="Pkg.UPDATED_REGISTRY_THIS_SESSION[] = true"
+fi
+
+# If the user wants to use SSH to clone packages during instantiation, allow for that here
+USE_SSH_BLOCK=""
+if [[ "${BUILDKITE_PLUGIN_JULIA_TEST_USE_SSH:-false}" == "true" ]]; then
+    USE_SSH_BLOCK='
+        if VERSION >= v"1.2"
+            Pkg.setprotocol!(protocol="ssh")
+        else
+            Pkg.setprotocol!("ssh")
+        end
+    '
+fi
+
+# If the user has some extra registries they want to add, we build a Pkg command to do that here
+# assume that the user always wants to include General, and that all registries are referred to by URL.
+ADD_REGISTRIES_BLOCK=""
+if [[ -n "${BUILDKITE_PLUGIN_JULIA_TEST_EXTRA_REGISTRIES:-}" ]]; then
+    ADD_REGISTRIES_BLOCK='
+        # Sadly, Julia 1.0 does not know how to do this.
+        if VERSION < v"1.1"
+            error("Custom registries cannot be programmatically added on Julia 1.0.X")
+        end
+
+        Pkg.Registry.add([
+            RegistrySpec(name="General"),
+    '
+    for url in $(echo ${BUILDKITE_PLUGIN_JULIA_TEST_EXTRA_REGISTRIES} | tr ',' ' '); do
+        ADD_REGISTRIES_BLOCK+="
+            RegistrySpec(url=\"${url}\"),
+        "
+    done
+    ADD_REGISTRIES_BLOCK+='])'
+fi

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -1,11 +1,15 @@
 #!/bin/bash
-set -euo pipefail
+source $(dirname ${BASH_SOURCE})/common
 
 echo "--- :julia: Instantiating project"
 
-julia --project -e 'using Pkg
-                    Pkg.UPDATED_REGISTRY_THIS_SESSION[] = true
+julia --project=${project} -e "
+    using Pkg
+    ${REGISTRY_SKIP_BLOCK}
+    ${USE_SSH_BLOCK}
+    ${ADD_REGISTRIES_BLOCK}
 
-                    Pkg.instantiate()
-                    Pkg.build()
-                    Pkg.status()'
+    Pkg.instantiate()
+    Pkg.build()
+    Pkg.status()
+"

--- a/plugin.yml
+++ b/plugin.yml
@@ -10,4 +10,12 @@ configuration:
       type: string
     test_args:
       type: string
+    use_ssh:
+      type: boolean
+    project:
+      type: string
+    update_registry:
+      type: boolean
+    extra_registries:
+      type: string
   additionalProperties: false

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -1,0 +1,123 @@
+#!/usr/bin/env bats
+
+load "$BATS_PATH/load.bash"
+
+# Create fake "julia" command that just prints out its invocation
+echo '#!/bin/bash
+echo julia "$@"' > /usr/bin/julia
+chmod +x /usr/bin/julia
+
+@test "Basic Instantiation" {
+    run $PWD/hooks/pre-command
+
+    assert_output --partial " --project=. "
+    assert_output --partial "Pkg.instantiate()"
+    assert_output --partial "Pkg.build()"
+    assert_output --partial "Pkg.status()"
+
+    # None of these should be present, by default
+    refute_output --partial "Pkg.UPDATED_REGISTRY_THIS_SESSION"
+    refute_output --partial "Pkg.setprotocol!"
+    refute_output --partial "Pkg.Registry.add"
+
+    assert_success
+}
+
+@test "Basic Testing" {
+    run $PWD/hooks/command
+
+    assert_output --partial " --project=. "
+    assert_output --partial "Pkg.test("
+    assert_output --partial "coverage=true"
+    assert_output --partial "julia_args=\`\`"
+    assert_output --partial "test_args=\`\`"
+    assert_output --partial "Pkg.UPDATED_REGISTRY_THIS_SESSION[] = true"
+
+    # None of these should be present by default
+    refute_output --partial "Pkg.setprotocol!"
+
+    assert_success
+}
+
+@test "Project setting (Instantiation)" {
+    export BUILDKITE_PLUGIN_JULIA_TEST_PROJECT="examples/foo"
+    run $PWD/hooks/pre-command
+
+    assert_output --partial " --project=examples/foo "
+    assert_success
+    unset BUILDKITE_PLUGIN_JULIA_TEST_PROJECT
+}
+
+@test "Project setting (Testing)" {
+    export BUILDKITE_PLUGIN_JULIA_TEST_PROJECT="examples/foo"
+    run $PWD/hooks/command
+
+    assert_output --partial " --project=examples/foo "
+    assert_success
+    unset BUILDKITE_PLUGIN_JULIA_TEST_PROJECT
+}
+
+@test "Parameter Setting: coverage" {
+    export BUILDKITE_PLUGIN_JULIA_TEST_COVERAGE="false"
+    run $PWD/hooks/command
+
+    assert_output --partial "coverage=false"
+    assert_success
+    unset BUILDKITE_PLUGIN_JULIA_TEST_COVERAGE
+}
+
+@test "Parameter Setting: julia_args" {
+    export BUILDKITE_PLUGIN_JULIA_TEST_JULIA_ARGS="-O0"
+    run $PWD/hooks/command
+
+    assert_output --partial "julia_args=\`-O0\`"
+    assert_success
+    unset BUILDKITE_PLUGIN_JULIA_TEST_JULIA_ARGS
+}
+
+@test "Parameter Setting: test_args" {
+    export BUILDKITE_PLUGIN_JULIA_TEST_TEST_ARGS="foo"
+    run $PWD/hooks/command
+
+    assert_output --partial "test_args=\`foo\`"
+    assert_success
+    unset BUILDKITE_PLUGIN_JULIA_TEST_TEST_ARGS
+}
+
+@test "Registry update skipping" {
+    export BUILDKITE_PLUGIN_JULIA_TEST_UPDATE_REGISTRY="false"
+    run $PWD/hooks/pre-command
+
+    assert_output --partial "Pkg.UPDATED_REGISTRY_THIS_SESSION[] = true"
+    assert_success
+    unset BUILDKITE_PLUGIN_JULIA_TEST_UPDATE_REGISTRY
+}
+
+@test "Using SSH to clone packages (Instantiation)" {
+    export BUILDKITE_PLUGIN_JULIA_TEST_USE_SSH="true"
+    run $PWD/hooks/command
+
+    assert_output --partial "Pkg.setprotocol!("
+    assert_success
+    unset BUILDKITE_PLUGIN_JULIA_TEST_USE_SSH
+}
+
+@test "Using SSH to clone packages (Testing)" {
+    export BUILDKITE_PLUGIN_JULIA_TEST_USE_SSH="true"
+    run $PWD/hooks/pre-command
+
+    assert_output --partial "Pkg.setprotocol!("
+    assert_success
+    unset BUILDKITE_PLUGIN_JULIA_TEST_USE_SSH
+}
+
+@test "Extra Registries" {
+    export BUILDKITE_PLUGIN_JULIA_TEST_EXTRA_REGISTRIES="https://github.com/JuliaRegistries/Test,https://github.com/JuliaRegistries/Test2"
+    run $PWD/hooks/pre-command
+
+    assert_output --partial 'RegistrySpec(name="General")'
+    assert_output --partial 'RegistrySpec(url="https://github.com/JuliaRegistries/Test")'
+    assert_output --partial 'RegistrySpec(url="https://github.com/JuliaRegistries/Test2")'
+    assert_success
+    unset BUILDKITE_PLUGIN_JULIA_TEST_EXTRA_REGISTRIES
+}


### PR DESCRIPTION
This PR adds plugin options to:

* Add custom registries before instantiation.  Combined with the SSH
  protocol setting, this allows for private packages/private registries
  to be used alongside deployed SSH keys for authentication to GitHub.

* Setting the project to be tested.  In a monorepo environment, it is
  useful to be able to set the `--project` parameter to something
  custom.

* Defaults to updating the registry (as my recent PR to the `julia`
  plugin would no longer update the registry there), but with an option
  to disable this if it is unwanted.

It also adds tests for option parsing, but doesn't actually run Julia, it just checks that the julia commands generated look approximately right.

X-ref: https://github.com/JuliaCI/julia-buildkite-plugin/pull/11