### PR TITLE
Add `upload_rr_trace` plugin option

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -2,7 +2,7 @@
 source $(dirname ${BASH_SOURCE})/common
 
 echo "+++ :julia: Running tests"
-julia --project=${project} -e "
+julia ${bugreport_args} --project=${project} -e "
     using Pkg
 
     # We never update the registry when running tests, we assume if you wanted this done, you'd do it in the pre-command

--- a/hooks/common
+++ b/hooks/common
@@ -5,6 +5,10 @@ coverage=${BUILDKITE_PLUGIN_JULIA_TEST_COVERAGE:-true}
 julia_args=${BUILDKITE_PLUGIN_JULIA_TEST_JULIA_ARGS:-""}
 test_args=${BUILDKITE_PLUGIN_JULIA_TEST_TEST_ARGS:-""}
 project=${BUILDKITE_PLUGIN_JULIA_TEST_PROJECT:-.}
+upload_rr_trace=${BUILDKITE_PLUGIN_JULIA_TEST_UPLOAD_RR_TRACE:-never}
+
+CACHE_DIR=${BUILDKITE_PLUGIN_JULIA_CACHE_DIR:-${HOME}/.cache/julia-test-buildkite-plugin}
+export _RR_TRACE_DIR=${CACHE_DIR}/rr_traces/${BUILDKITE_BUILD_ID}
 
 # Allow the user to purposefully skip updating the registry (e.g. we know it's already been done)
 REGISTRY_SKIP_BLOCK=""
@@ -43,4 +47,9 @@ if [[ -n "${BUILDKITE_PLUGIN_JULIA_TEST_EXTRA_REGISTRIES:-}" ]]; then
         "
     done
     ADD_REGISTRIES_BLOCK+='])'
+fi
+
+bugreport_args=""
+if [[ "${upload_rr_trace}" != "never" ]]; then
+    bugreport_args="--bug-report=rr-local --"
 fi

--- a/hooks/pack_rr_trace.jl
+++ b/hooks/pack_rr_trace.jl
@@ -1,0 +1,16 @@
+# Install `BugReporting` into a temporary environment
+using Pkg
+Pkg.activate(; temp=true)
+Pkg.add("BugReporting")
+using BugReporting
+
+# Compress the latest trace recorded in our overall trace directory
+trace_dir = BugReporting.find_latest_trace(ENV["_RR_TRACE_DIR"])
+mktempdir() do dir
+    pipeline = ENV["BUILDKITE_PIPELINE_NAME"]
+    commit = ENV["BUILDKITE_COMMIT"]
+    step_id = ENV["BUILDKITE_STEP_ID"]
+    tarzst_path = joinpath(dir, "$(pipeline)-$(commit)-$(step_id).tar.zst")
+    BugReporting.compress_trace(trace_dir, tarzst_path)
+    run(`buildkite-agent artifact upload $(tarzst_path)`)
+end

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -1,0 +1,11 @@
+#!/bin/bash
+source $(dirname ${BASH_SOURCE})/common
+
+# If we either always upload a trace (or only upload on error), pack it and append it to our artifact paths
+if [[ "${upload_rr_trace}" == "always" ]] || ( [[ "${upload_rr_trace}" == "error" ]] && [[ "${BUILDKITE_COMMAND_EXIT_STATUS}" != "0" ]] ); then
+    # Pack the trace directory into a .tar.zst
+    julia $(dirname ${BASH_SOURCE})/pack_rr_trace.jl
+fi
+
+# Clean up our `rr` directory no matter what
+rm -rf "${_RR_TRACE_DIR}"

--- a/plugin.yml
+++ b/plugin.yml
@@ -18,4 +18,6 @@ configuration:
       type: boolean
     extra_registries:
       type: string
+    upload_rr_trace:
+      type: string
   additionalProperties: false

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -19,6 +19,7 @@ chmod +x /usr/bin/julia
     refute_output --partial "Pkg.UPDATED_REGISTRY_THIS_SESSION"
     refute_output --partial "Pkg.setprotocol!"
     refute_output --partial "Pkg.Registry.add"
+    refute_output --partial "bug-report"
 
     assert_success
 }
@@ -82,6 +83,15 @@ chmod +x /usr/bin/julia
     assert_output --partial "test_args=\`foo\`"
     assert_success
     unset BUILDKITE_PLUGIN_JULIA_TEST_TEST_ARGS
+}
+
+@test "Parameter Setting: upload_rr_trace" {
+    export BUILDKITE_PLUGIN_JULIA_TEST_UPLOAD_RR_TRACE="always"
+    run $PWD/hooks/command
+
+    assert_output --partial "bug-report"
+    assert_success
+    unset BUILDKITE_PLUGIN_JULIA_TEST_UPLOAD_RR_TRACE
 }
 
 @test "Registry update skipping" {


### PR DESCRIPTION
This option has possible settings:

* `never` (the default): this does not run your tests inside of `rr` at all.

* `always`: This uploads the recorded `rr` trace unconditionally.

* `error`: This uploads the recorded `rr` trace if your test process
ended with a non-zero exit code.