### PR TITLE
Don't hard-code path to bash.

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source $(dirname ${BASH_SOURCE})/common
 
 # Use default julia test running harness

--- a/hooks/common
+++ b/hooks/common
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 coverage=${BUILDKITE_PLUGIN_JULIA_TEST_COVERAGE:-true}

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source $(dirname ${BASH_SOURCE})/common
 
 # If we either always upload a trace (or only upload on error), pack it and append it to our artifact paths

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source $(dirname ${BASH_SOURCE})/common
 
 echo "--- :julia: Instantiating project"


### PR DESCRIPTION
Some of the features used here aren't compatible with macOS' system bash (v3.something), so we want to be able to use a more recent version.