### PR TITLE
Use specific exit code for instantiation failures

### DIFF
--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -17,4 +17,4 @@ julia --project=${project} -e "
     Pkg.instantiate()
     Pkg.build()
     Pkg.status()
-"
+" || exit 3


### PR DESCRIPTION
For downstream testing, when a package releases a breaking version all dependents will fail to instantiate, resulting in a failed job. This may be unwanted, so make it possible to discern this situation by using a separate exit code.