### PR TITLE
Allow disabling `allow_reresolve` in `Pkg.test()`.

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -27,7 +27,8 @@ if [[ "${run_tests}" == "true" ]]; then
 
         Pkg.test(${PKG}; coverage=$coverage,
                     julia_args=\`$julia_args\`,
-                    test_args=\`$test_args\`)
+                    test_args=\`$test_args\`,
+                    ${ALLOW_RERESOLVE_LINE})
     "
 fi
 

--- a/hooks/common
+++ b/hooks/common
@@ -52,6 +52,11 @@ if [[ -n "${BUILDKITE_PLUGIN_JULIA_TEST_EXTRA_REGISTRIES:-}" ]]; then
     ADD_REGISTRIES_BLOCK+='])'
 fi
 
+ALLOW_RERESOLVE_LINE=""
+if [[ "${BUILDKITE_PLUGIN_JULIA_TEST_ALLOW_RERESOLVE:-true}" != "true" ]]; then
+    ALLOW_RERESOLVE_LINE="allow_reresolve=${BUILDKITE_PLUGIN_JULIA_TEST_ALLOW_RERESOLVE},"
+fi
+
 bugreport_args=""
 if [[ "${upload_rr_trace}" != "never" ]]; then
     bugreport_args="--bug-report=rr-local --"

--- a/plugin.yml
+++ b/plugin.yml
@@ -45,5 +45,8 @@ configuration:
     # Extra test args (passes `test_args` to `Pkg.test()`), defaults to `""`
     test_args:
       type: string
+    # Whether to allow Pkg to automatically re-resolve manifests if used with an incompatible Julia version, defaults to `true`
+    allow_reresolve:
+      type: boolean
 
   additionalProperties: false


### PR DESCRIPTION
This allows CI pipelines to denote that they should not allow Pkg to reresolve if used with an incompatible Julia version.  This is useful for ensuring that a Manifest.toml is actually used exactly as written.