### PR TITLE
Load Pkg outside of the package's project

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -17,7 +17,7 @@ if [[ "${run_tests}" == "true" ]]; then
     fi
     julia ${bugreport_args} --color=yes -e "
         using Pkg
-        Pkg.activate(ARGS[1])
+        Pkg.activate(\"${project}\")
 
         # We never update the registry when running tests, we assume if you wanted this done,
         # you'd do it in the pre-command
@@ -31,7 +31,7 @@ if [[ "${run_tests}" == "true" ]]; then
                     julia_args=\`$julia_args\`,
                     test_args=\`$test_args\`,
                     ${ALLOW_RERESOLVE_LINE})
-    " ${project}
+    "
 fi
 
 # Restore the original Manifest

--- a/hooks/command
+++ b/hooks/command
@@ -15,10 +15,12 @@ if [[ "${run_tests}" == "true" ]]; then
     else
         PKG="\"${package}\""
     fi
-    julia ${bugreport_args} --color=yes --project=${project} -e "
+    julia ${bugreport_args} --color=yes -e "
         using Pkg
+        Pkg.activate(ARGS[1])
 
-        # We never update the registry when running tests, we assume if you wanted this done, you'd do it in the pre-command
+        # We never update the registry when running tests, we assume if you wanted this done,
+        # you'd do it in the pre-command
         Pkg.UPDATED_REGISTRY_THIS_SESSION[] = true
 
         # In the event that you might need to fetch test-only dependencies that are private,
@@ -29,7 +31,7 @@ if [[ "${run_tests}" == "true" ]]; then
                     julia_args=\`$julia_args\`,
                     test_args=\`$test_args\`,
                     ${ALLOW_RERESOLVE_LINE})
-    "
+    " ${project}
 fi
 
 # Restore the original Manifest

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -11,7 +11,7 @@ fi
 JULIA_PKG_PRECOMPILE_AUTO=0 \
 julia -e "
     using Pkg
-    Pkg.activate(ARGS[1])
+    Pkg.activate(\"${project}\")
 
     ${REGISTRY_SKIP_BLOCK}
     ${USE_SSH_BLOCK}
@@ -20,4 +20,4 @@ julia -e "
     Pkg.instantiate()
     Pkg.build()
     Pkg.status()
-" ${project}
+"

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -9,8 +9,10 @@ if [ -n "$custom_manifest" ]; then
 fi
 
 JULIA_PKG_PRECOMPILE_AUTO=0 \
-julia --project=${project} -e "
+julia -e "
     using Pkg
+    Pkg.activate(ARGS[1])
+
     ${REGISTRY_SKIP_BLOCK}
     ${USE_SSH_BLOCK}
     ${ADD_REGISTRIES_BLOCK}
@@ -18,4 +20,4 @@ julia --project=${project} -e "
     Pkg.instantiate()
     Pkg.build()
     Pkg.status()
-"
+" ${project}


### PR DESCRIPTION
Even though, AFAIU, `Pkg.instantiate` has been made resilient now to loading older manifests where certain dependencies are missing, that doesn't apply to loading Pkg itself. So let's try doing that in the default environment, and switching projects after that.